### PR TITLE
Prime compare website properly displays Lighthouse test iFrames

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,11 +2,9 @@ module.exports = () => {
 return `const md5File = require('md5-file');
 const path = require('path');
 
-// CSS styles will be imported on load and that complicates matters... ignore those bad boys!
+// Ignore CSS styles imported on load
 const ignoreStyles = require('ignore-styles');
 const register = ignoreStyles.default;
-
-// We also want to ignore all image requests// CSS styles will be imported on load and that complicates matters... ignore those bad boys!
 
 // When running locally these will load from a standard import
 // When running on the server, we want to load via their hashed version in the build folder

--- a/lib/performanceTest/createCompareHTML.js
+++ b/lib/performanceTest/createCompareHTML.js
@@ -108,7 +108,7 @@ return `<!DOCTYPE html>
         </div>
         <iframe id="csr-iframe" src="http://localhost:${input.port}"></iframe>
         <div>
-          <div id="button1" class="btn purple" onClick='document.getElementById("csr-report-iframe").src="./csr-report.html";window.scrollBy(0, 600);' className="btn purple">VIEW
+          <div id="button1" class="btn purple" onClick='document.getElementById("csr-report-iframe").src="http://localhost:5050/csr-report";window.scrollBy(0, 600);' className="btn purple">VIEW
             REPORT
           </div>
           <iframe id='csr-report-iframe' frameborder="0"></iframe>
@@ -120,7 +120,7 @@ return `<!DOCTYPE html>
         </div>
         <iframe id="ssr-iframe" src="http://localhost:8080"></iframe>
         <div>
-          <div id="button2" class="btn purple" onClick='document.getElementById("ssr-report-iframe").src="./ssr-report.html";window.scrollBy(0, 600);' className="btn purple">VIEW
+          <div id="button2" class="btn purple" onClick='document.getElementById("ssr-report-iframe").src="http://localhost:5050/ssr-report";window.scrollBy(0, 600);' className="btn purple">VIEW
             REPORT
           </div>
           <iframe id='ssr-report-iframe' frameborder="0"></iframe>

--- a/lib/performanceTest/createConfig.js
+++ b/lib/performanceTest/createConfig.js
@@ -1,0 +1,12 @@
+module.exports = () => {
+return `module.exports = {
+  extends: 'lighthouse:default',
+  settings: {
+    onlyAudits: [
+      'first-meaningful-paint',
+      'speed-index-metric',
+      'estimated-input-latency',
+    ],
+  },
+}`;
+};

--- a/lib/performanceTest/createPrimeServer.js
+++ b/lib/performanceTest/createPrimeServer.js
@@ -6,6 +6,9 @@ const app = express();
 
 const port = 5050;
 
+app.use('/csr-report', express.static(path.join(__dirname, './reports/csr-report.html')));
+app.use('/ssr-report', express.static(path.join(__dirname, './reports/ssr-report.html')));
+
 app.get('/', (req, res) => {
   res.sendFile(path.join(__dirname, './primeCompare.html'));
 });


### PR DESCRIPTION
To prevent lighthouse from hanging indefinitely, the scripts for generating the CSR and SSR reports have been separated into their own scripts. The user will have to manually run these after running prime:compare if they want to see the lighthouse reports. 